### PR TITLE
Allow disabling specific slack notifications based on env vars

### DIFF
--- a/lambda/iam-notify-slack.py
+++ b/lambda/iam-notify-slack.py
@@ -3,6 +3,15 @@ import os
 from slacker import Slacker
 
 
+# Default return for not found or fail to parse is True
+# Explicitly setting to 0/False will return a False
+def env_var_to_bool(env_var):
+    try:
+        return int(os.environ.get(env_var, '1'))
+    except BaseException:
+        return True
+
+
 def send_to_slack(message, attachment, channel, key):
     status = True
     print("sending slack message " + message)
@@ -48,35 +57,50 @@ def lambda_handler(event, context):
         event_name = event['detail']['eventName']
 
         if event_name == "CreatePolicy":
-            post_to_slack = True
-            object_field_name = ""
-            object_field_value = ""
-            policy_name = event['detail']['requestParameters']['policyName']
-            policy_arn = event['detail']['responseElements']['policy']['arn']
+            if env_var_to_bool('CREATE_POLICY_NOTIFY'):
+                post_to_slack = True
+                object_field_name = ""
+                object_field_value = ""
+                policy_name = event['detail']['requestParameters']['policyName']
+                policy_arn = event['detail']['responseElements']['policy']['arn']
+            else:
+                print('{} environment variable evaluated as False, not notifying slack'.format('CREATE_POLICY_NOTIFY'))
         elif event_name == "CreatePolicyVersion":
-            post_to_slack = True
-            object_field_name = ""
-            object_field_value = ""
-            policy_name = event['detail']['requestParameters']['policyArn'].split(':')[5]
-            policy_arn = event['detail']['requestParameters']['policyArn']
+            if env_var_to_bool('CREATE_POLICY_VERSION_NOTIFY'):
+                post_to_slack = True
+                object_field_name = ""
+                object_field_value = ""
+                policy_name = event['detail']['requestParameters']['policyArn'].split(':')[5]
+                policy_arn = event['detail']['requestParameters']['policyArn']
+            else:
+                print('{} environment variable evaluated as False, not notifying slack'.format('CREATE_POLICY_VERSION_NOTIFY'))
         elif event_name == "AttachGroupPolicy" or event_name == "DetachGroupPolicy":
-            post_to_slack = True
-            object_field_name = "Group"
-            object_field_value = event['detail']['requestParameters']['groupName']
-            policy_name = event['detail']['requestParameters']['policyArn'].split(':')[5]
-            policy_arn = event['detail']['requestParameters']['policyArn']
+            if env_var_to_bool('ATTACH_GROUP_POLICY_NOTIFY') and env_var_to_bool('DETACH_GROUP_POLICY_NOTIFY'):
+                post_to_slack = True
+                object_field_name = "Group"
+                object_field_value = event['detail']['requestParameters']['groupName']
+                policy_name = event['detail']['requestParameters']['policyArn'].split(':')[5]
+                policy_arn = event['detail']['requestParameters']['policyArn']
+            else:
+                print('{}, {} environment variables evaluated as False, not notifying slack'.format('ATTACH_GROUP_POLICY_NOTIFY', 'DETACH_GROUP_POLICY_NOTIFY'))
         elif event_name == "AttachUserPolicy" or event_name == "DetachUserPolicy":
-            post_to_slack = True
-            object_field_name = "User"
-            object_field_value = event['detail']['requestParameters']['userName']
-            policy_name = event['detail']['requestParameters']['policyArn'].split(':')[5]
-            policy_arn = event['detail']['requestParameters']['policyArn']
+            if env_var_to_bool('ATTACH_USER_POLICY_NOTIFY') and env_var_to_bool('DETACH_USER_POLICY_NOTIFY'):
+                post_to_slack = True
+                object_field_name = "User"
+                object_field_value = event['detail']['requestParameters']['userName']
+                policy_name = event['detail']['requestParameters']['policyArn'].split(':')[5]
+                policy_arn = event['detail']['requestParameters']['policyArn']
+            else:
+                print('{}, {} environment variables evaluated as False, not notifying slack'.format('ATTACH_USER_POLICY_NOTIFY', 'DETACH_USER_POLICY_NOTIFY'))
         elif event_name == "AttachRolePolicy" or event_name == "DetachRolePolicy":
-            post_to_slack = True
-            object_field_name = "Role"
-            object_field_value = event['detail']['requestParameters']['roleName']
-            policy_name = event['detail']['requestParameters']['policyArn'].split(':')[5]
-            policy_arn = event['detail']['requestParameters']['policyArn']
+            if env_var_to_bool('ATTACH_ROLE_POLICY_NOTIFY') and env_var_to_bool('DETACH_ROLE_POLICY_NOTIFY'):
+                post_to_slack = True
+                object_field_name = "Role"
+                object_field_value = event['detail']['requestParameters']['roleName']
+                policy_name = event['detail']['requestParameters']['policyArn'].split(':')[5]
+                policy_arn = event['detail']['requestParameters']['policyArn']
+            else:
+                print('{}, {} environment variables evaluated as False, not notifying slack'.format('ATTACH_ROLE_POLICY_NOTIFY', 'DETACH_ROLE_POLICY_NOTIFY'))
         else:
             print("No support for event " + event_name)
             print("Received event: " + json.dumps(event, indent=2))


### PR DESCRIPTION
Alot of my stuff is automated and some of these alerts will cause alarm fatigue.
Allow disabling per slack alert, but all of which are opt-in by default (no change in default behavior from current workflow)